### PR TITLE
fix: HttpClientWithCache could not be resolved from DI

### DIFF
--- a/src/Reliable.HttpClient.Caching/Extensions/HttpClientWithCacheExtensions.cs
+++ b/src/Reliable.HttpClient.Caching/Extensions/HttpClientWithCacheExtensions.cs
@@ -17,27 +17,88 @@ public static class HttpClientWithCacheExtensions
     /// </summary>
     /// <param name="services">Service collection</param>
     /// <param name="httpClientName">HTTP client name (optional)</param>
-    /// <param name="configureCacheOptions">Action to configure cache options</param>
+    /// <param name="cacheOptions">Cache options including default headers and settings (optional)</param>
     /// <returns>Service collection for method chaining</returns>
     public static IServiceCollection AddHttpClientWithCache(
-        this IServiceCollection services,
-        string? httpClientName = null,
-        Action<HttpCacheOptions>? configureCacheOptions = null)
+    this IServiceCollection services,
+    string? httpClientName = null,
+    HttpCacheOptions? cacheOptions = null)
     {
         // Register dependencies
         services.AddMemoryCache();
         services.AddSingleton<ISimpleCacheKeyGenerator, DefaultSimpleCacheKeyGenerator>();
 
-        if (configureCacheOptions is not null)
-        {
-            services.Configure(httpClientName, configureCacheOptions);
-        }
-
         // Register the universal HTTP client with cache as scoped to avoid captive dependency
-        services.AddScoped<IHttpClientWithCache>(sp => CreateHttpClientWithCache(sp, httpClientName));
+        services.AddScoped<IHttpClientWithCache>(sp => CreateHttpClientWithCache(sp, httpClientName, cacheOptions));
         services.AddScoped(sp => (HttpClientWithCache)sp.GetRequiredService<IHttpClientWithCache>());
 
         return services;
+    }
+
+    /// <summary>
+    /// Adds universal HTTP client with caching to the service collection
+    /// </summary>
+    /// <param name="services">Service collection</param>
+    /// <param name="httpClientName">HTTP client name (optional)</param>
+    /// <param name="configureCacheOptions">Action to configure cache options
+    /// which then will be registered as <see cref="IOptions{TOptions}"/> named after <paramref name="httpClientName"/></param>
+    /// <returns>Service collection for method chaining</returns>
+    public static IServiceCollection AddHttpClientWithCache(
+        this IServiceCollection services,
+        string? httpClientName,
+        Action<HttpCacheOptions> configureCacheOptions)
+    {
+        var options = new HttpCacheOptions();
+        configureCacheOptions(options);
+        services.Configure(httpClientName, configureCacheOptions);
+
+        return services.AddHttpClientWithCache(httpClientName, options);
+    }
+
+    /// <summary>
+    /// Adds universal HTTP client with caching and resilience to the service collection
+    /// </summary>
+    /// <param name="services">Service collection</param>
+    /// <param name="httpClientName">HTTP client name</param>
+    /// <param name="configureResilience">Action to configure resilience options</param>
+    /// <param name="cacheOptions">Cache options including default headers and settings (optional)</param>
+    /// <returns>Service collection for method chaining</returns>
+    public static IServiceCollection AddResilientHttpClientWithCache(
+        this IServiceCollection services,
+        string httpClientName,
+        Action<HttpClientOptions>? configureResilience = null,
+        HttpCacheOptions? cacheOptions = null)
+    {
+        // Add HTTP client with resilience
+        services.AddHttpClient(httpClientName)
+                .AddResilience(configureResilience);
+
+        // Add universal HTTP client with cache
+        return services.AddHttpClientWithCache(httpClientName, cacheOptions);
+    }
+
+    /// <summary>
+    /// Adds universal HTTP client with caching using preset resilience configuration
+    /// </summary>
+    /// <param name="services">Service collection</param>
+    /// <param name="httpClientName">HTTP client name</param>
+    /// <param name="preset">Predefined resilience preset</param>
+    /// <param name="customizeOptions">Optional action to customize preset options</param>
+    /// <param name="cacheOptions">Cache options including default headers and settings (optional)</param>
+    /// <returns>Service collection for method chaining</returns>
+    public static IServiceCollection AddResilientHttpClientWithCache(
+        this IServiceCollection services,
+        string httpClientName,
+        HttpClientOptions preset,
+        Action<HttpClientOptions>? customizeOptions = null,
+        HttpCacheOptions? cacheOptions = null)
+    {
+        // Add HTTP client with resilience preset
+        services.AddHttpClient(httpClientName)
+                .AddResilience(preset, customizeOptions);
+
+        // Add universal HTTP client with cache
+        return services.AddHttpClientWithCache(httpClientName, cacheOptions);
     }
 
     /// <summary>
@@ -51,15 +112,14 @@ public static class HttpClientWithCacheExtensions
     public static IServiceCollection AddResilientHttpClientWithCache(
         this IServiceCollection services,
         string httpClientName,
-        Action<HttpClientOptions>? configureResilience = null,
-        Action<HttpCacheOptions>? configureCacheOptions = null)
+        Action<HttpCacheOptions> configureCacheOptions,
+        Action<HttpClientOptions>? configureResilience = null)
     {
-        // Add HTTP client with resilience
-        services.AddHttpClient(httpClientName)
-                .AddResilience(configureResilience);
+        var cacheOptions = new HttpCacheOptions();
+        configureCacheOptions(cacheOptions);
+        services.Configure(httpClientName, configureCacheOptions);
 
-        // Add universal HTTP client with cache
-        return services.AddHttpClientWithCache(httpClientName, configureCacheOptions);
+        return services.AddResilientHttpClientWithCache(httpClientName, configureResilience, cacheOptions);
     }
 
     /// <summary>
@@ -75,15 +135,14 @@ public static class HttpClientWithCacheExtensions
         this IServiceCollection services,
         string httpClientName,
         HttpClientOptions preset,
-        Action<HttpClientOptions>? customizeOptions = null,
-        Action<HttpCacheOptions>? configureCacheOptions = null)
+        Action<HttpCacheOptions> configureCacheOptions,
+        Action<HttpClientOptions>? customizeOptions = null)
     {
-        // Add HTTP client with resilience preset
-        services.AddHttpClient(httpClientName)
-                .AddResilience(preset, customizeOptions);
+        var cacheOptions = new HttpCacheOptions();
+        configureCacheOptions(cacheOptions);
+        services.Configure(httpClientName, configureCacheOptions);
 
-        // Add universal HTTP client with cache
-        return services.AddHttpClientWithCache(httpClientName, configureCacheOptions);
+        return services.AddResilientHttpClientWithCache(httpClientName, preset, customizeOptions, cacheOptions);
     }
 
     /// <summary>
@@ -91,13 +150,15 @@ public static class HttpClientWithCacheExtensions
     /// </summary>
     /// <param name="serviceProvider">The service provider used to resolve required dependencies.</param>
     /// <param name="httpClientName">The name of the HTTP client to retrieve from the <see cref="IHttpClientFactory"/>.
+    /// <param name="cacheOptions">Cache options including default headers and settings (optional)</param>
     /// If null or empty, a default client is created.</param>
     /// <returns>A configured instance of <see cref="HttpClientWithCache"/>.</returns>
     /// <exception cref="InvalidOperationException">Thrown if a required service (e.g., <see cref="IHttpClientFactory"/>, <see cref="IMemoryCache"/>, 
     /// <see cref="IHttpResponseHandler"/>, or <see cref="ISimpleCacheKeyGenerator"/>) is not registered in the service provider.</exception>
     private static HttpClientWithCache CreateHttpClientWithCache(
         IServiceProvider serviceProvider,
-        string? httpClientName)
+        string? httpClientName,
+        HttpCacheOptions? cacheOptions)
     {
         IHttpClientFactory httpClientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();
         System.Net.Http.HttpClient httpClient = httpClientName is null or ""
@@ -106,6 +167,9 @@ public static class HttpClientWithCacheExtensions
 
         IMemoryCache cache = serviceProvider.GetRequiredService<IMemoryCache>();
         IHttpResponseHandler responseHandler = serviceProvider.GetRequiredService<IHttpResponseHandler>();
+        HttpCacheOptions? cacheOptionsToInject = cacheOptions is null
+            ? serviceProvider.GetService<IOptionsSnapshot<HttpCacheOptions>>()?.Get(httpClientName)
+            : cacheOptions;
         IOptionsSnapshot<HttpCacheOptions>? cacheOptionsSnapshot = serviceProvider.GetService<IOptionsSnapshot<HttpCacheOptions>>();
         ISimpleCacheKeyGenerator cacheKeyGenerator = serviceProvider.GetRequiredService<ISimpleCacheKeyGenerator>();
         ILogger<HttpClientWithCache>? logger = serviceProvider.GetService<ILogger<HttpClientWithCache>>();
@@ -114,7 +178,7 @@ public static class HttpClientWithCacheExtensions
             httpClient,
             cache,
             responseHandler,
-            cacheOptionsSnapshot?.Get(httpClientName),
+            cacheOptionsToInject,
             cacheKeyGenerator,
             logger);
     }

--- a/src/Reliable.HttpClient.Caching/Extensions/HttpClientWithCacheExtensions.cs
+++ b/src/Reliable.HttpClient.Caching/Extensions/HttpClientWithCacheExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 using Reliable.HttpClient.Caching.Abstractions;
 
@@ -16,38 +17,25 @@ public static class HttpClientWithCacheExtensions
     /// </summary>
     /// <param name="services">Service collection</param>
     /// <param name="httpClientName">HTTP client name (optional)</param>
-    /// <param name="cacheOptions">Cache options including default headers and settings (optional)</param>
+    /// <param name="configureCacheOptions">Action to configure cache options</param>
     /// <returns>Service collection for method chaining</returns>
     public static IServiceCollection AddHttpClientWithCache(
         this IServiceCollection services,
         string? httpClientName = null,
-        HttpCacheOptions? cacheOptions = null)
+        Action<HttpCacheOptions>? configureCacheOptions = null)
     {
         // Register dependencies
         services.AddMemoryCache();
         services.AddSingleton<ISimpleCacheKeyGenerator, DefaultSimpleCacheKeyGenerator>();
 
-        // Register the universal HTTP client with cache
-        services.AddSingleton<IHttpClientWithCache>(serviceProvider =>
+        if (configureCacheOptions is not null)
         {
-            IHttpClientFactory httpClientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();
-            System.Net.Http.HttpClient httpClient = httpClientName is null or ""
-                ? httpClientFactory.CreateClient()
-                : httpClientFactory.CreateClient(httpClientName);
+            services.Configure(httpClientName, configureCacheOptions);
+        }
 
-            IMemoryCache cache = serviceProvider.GetRequiredService<IMemoryCache>();
-            IHttpResponseHandler responseHandler = serviceProvider.GetRequiredService<IHttpResponseHandler>(); // Use universal handler
-            ISimpleCacheKeyGenerator cacheKeyGenerator = serviceProvider.GetRequiredService<ISimpleCacheKeyGenerator>();
-            ILogger<HttpClientWithCache>? logger = serviceProvider.GetService<ILogger<HttpClientWithCache>>();
-
-            return new HttpClientWithCache(
-                httpClient,
-                cache,
-                responseHandler,
-                cacheOptions,
-                cacheKeyGenerator,
-                logger);
-        });
+        // Register the universal HTTP client with cache as scoped to avoid captive dependency
+        services.AddScoped<IHttpClientWithCache>(sp => CreateHttpClientWithCache(sp, httpClientName));
+        services.AddScoped(sp => (HttpClientWithCache)sp.GetRequiredService<IHttpClientWithCache>());
 
         return services;
     }
@@ -58,20 +46,20 @@ public static class HttpClientWithCacheExtensions
     /// <param name="services">Service collection</param>
     /// <param name="httpClientName">HTTP client name</param>
     /// <param name="configureResilience">Action to configure resilience options</param>
-    /// <param name="cacheOptions">Cache options including default headers and settings (optional)</param>
+    /// <param name="configureCacheOptions">Action to configure cache options</param>
     /// <returns>Service collection for method chaining</returns>
     public static IServiceCollection AddResilientHttpClientWithCache(
         this IServiceCollection services,
         string httpClientName,
         Action<HttpClientOptions>? configureResilience = null,
-        HttpCacheOptions? cacheOptions = null)
+        Action<HttpCacheOptions>? configureCacheOptions = null)
     {
         // Add HTTP client with resilience
         services.AddHttpClient(httpClientName)
                 .AddResilience(configureResilience);
 
         // Add universal HTTP client with cache
-        return services.AddHttpClientWithCache(httpClientName, cacheOptions);
+        return services.AddHttpClientWithCache(httpClientName, configureCacheOptions);
     }
 
     /// <summary>
@@ -81,20 +69,53 @@ public static class HttpClientWithCacheExtensions
     /// <param name="httpClientName">HTTP client name</param>
     /// <param name="preset">Predefined resilience preset</param>
     /// <param name="customizeOptions">Optional action to customize preset options</param>
-    /// <param name="cacheOptions">Cache options including default headers and settings (optional)</param>
+    /// <param name="configureCacheOptions">Action to configure cache options</param>
     /// <returns>Service collection for method chaining</returns>
     public static IServiceCollection AddResilientHttpClientWithCache(
         this IServiceCollection services,
         string httpClientName,
         HttpClientOptions preset,
         Action<HttpClientOptions>? customizeOptions = null,
-        HttpCacheOptions? cacheOptions = null)
+        Action<HttpCacheOptions>? configureCacheOptions = null)
     {
         // Add HTTP client with resilience preset
         services.AddHttpClient(httpClientName)
                 .AddResilience(preset, customizeOptions);
 
         // Add universal HTTP client with cache
-        return services.AddHttpClientWithCache(httpClientName, cacheOptions);
+        return services.AddHttpClientWithCache(httpClientName, configureCacheOptions);
+    }
+
+    /// <summary>
+    /// Creates an instance of <see cref="HttpClientWithCache"/> using the provided service provider and configuration.
+    /// </summary>
+    /// <param name="serviceProvider">The service provider used to resolve required dependencies.</param>
+    /// <param name="httpClientName">The name of the HTTP client to retrieve from the <see cref="IHttpClientFactory"/>.
+    /// If null or empty, a default client is created.</param>
+    /// <returns>A configured instance of <see cref="HttpClientWithCache"/>.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if a required service (e.g., <see cref="IHttpClientFactory"/>, <see cref="IMemoryCache"/>, 
+    /// <see cref="IHttpResponseHandler"/>, or <see cref="ISimpleCacheKeyGenerator"/>) is not registered in the service provider.</exception>
+    private static HttpClientWithCache CreateHttpClientWithCache(
+        IServiceProvider serviceProvider,
+        string? httpClientName)
+    {
+        IHttpClientFactory httpClientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();
+        System.Net.Http.HttpClient httpClient = httpClientName is null or ""
+            ? httpClientFactory.CreateClient()
+            : httpClientFactory.CreateClient(httpClientName);
+
+        IMemoryCache cache = serviceProvider.GetRequiredService<IMemoryCache>();
+        IHttpResponseHandler responseHandler = serviceProvider.GetRequiredService<IHttpResponseHandler>();
+        IOptionsSnapshot<HttpCacheOptions>? cacheOptionsSnapshot = serviceProvider.GetService<IOptionsSnapshot<HttpCacheOptions>>();
+        ISimpleCacheKeyGenerator cacheKeyGenerator = serviceProvider.GetRequiredService<ISimpleCacheKeyGenerator>();
+        ILogger<HttpClientWithCache>? logger = serviceProvider.GetService<ILogger<HttpClientWithCache>>();
+
+        return new HttpClientWithCache(
+            httpClient,
+            cache,
+            responseHandler,
+            cacheOptionsSnapshot?.Get(httpClientName),
+            cacheKeyGenerator,
+            logger);
     }
 }

--- a/tests/Reliable.HttpClient.Caching.Tests/HttpClientWithCacheExtensionsTests.cs
+++ b/tests/Reliable.HttpClient.Caching.Tests/HttpClientWithCacheExtensionsTests.cs
@@ -1,0 +1,141 @@
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+using Reliable.HttpClient.Caching.Abstractions;
+using Reliable.HttpClient.Caching.Extensions;
+
+namespace Reliable.HttpClient.Caching.Tests;
+
+public class HttpClientWithCacheExtensionsTests
+{
+    [Fact]
+    public void AddHttpClientWithCache_RegistersAllRequiredServices()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHttpClient();
+        services.AddSingleton<IHttpResponseHandler, DefaultHttpResponseHandler>();
+
+        // Act
+        services.AddHttpClientWithCache("CachedClient");
+        ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        // Assert
+        serviceProvider.GetService<IHttpClientWithCache>().Should().NotBeNull().And.BeOfType<HttpClientWithCache>();
+        serviceProvider.GetService<IMemoryCache>().Should().NotBeNull();
+        serviceProvider.GetService<ISimpleCacheKeyGenerator>().Should().NotBeNull();
+        serviceProvider.GetService<System.Net.Http.HttpClient>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddHttpClientWithCache_WithNamedClient_RegistersNamedHttpClient()
+    {
+        // Arrange
+        const string clientName = "CachedClient";
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHttpClient();
+        services.AddSingleton<IHttpResponseHandler, DefaultHttpResponseHandler>();
+
+        // Act
+        services.AddHttpClientWithCache(clientName);
+        ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        // Assert
+        IHttpClientFactory httpClientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();
+        System.Net.Http.HttpClient httpClient = httpClientFactory.CreateClient(clientName);
+        httpClient.Should().NotBeNull();
+
+        IHttpClientWithCache httpClientWithCache = serviceProvider.GetRequiredService<IHttpClientWithCache>();
+        httpClientWithCache.Should().NotBeNull().And.BeOfType<HttpClientWithCache>();
+    }
+
+    [Fact]
+    public void AddHttpClientWithCache_WithCacheOptions_AppliesCacheOptions()
+    {
+        // Arrange
+        const string clientName = "CachedClient";
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHttpClient();
+        services.AddSingleton<IHttpResponseHandler, DefaultHttpResponseHandler>();
+
+        // Act
+        services.AddHttpClientWithCache(clientName, options => options.DefaultExpiry = TimeSpan.FromMinutes(10));
+        ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        // Assert
+        var httpClientWithCache = serviceProvider.GetRequiredService<IHttpClientWithCache>() as HttpClientWithCache;
+        httpClientWithCache.Should().NotBeNull();
+
+        // Проверяем, что HttpCacheOptions правильно настроены для MediumTerm preset
+        // Используем IOptionsSnapshot для получения настроек именованного клиента "KodySuCached"
+        IOptionsSnapshot<HttpCacheOptions> optionsSnapshot = serviceProvider.GetRequiredService<IOptionsSnapshot<HttpCacheOptions>>();
+        HttpCacheOptions registeredOptions = optionsSnapshot.Get(clientName);
+
+        registeredOptions.DefaultExpiry.Should().Be(TimeSpan.FromMinutes(10));
+    }
+
+    [Fact]
+    public void AddResilientHttpClientWithCache_RegistersAllRequiredServices()
+    {
+        // Arrange
+        const string clientName = "ResilientClient";
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHttpClient();
+        services.AddSingleton<IHttpResponseHandler, DefaultHttpResponseHandler>();
+
+        // Act
+        services.AddResilientHttpClientWithCache(clientName);
+        ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        // Assert
+        IHttpClientFactory httpClientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();
+        System.Net.Http.HttpClient httpClient = httpClientFactory.CreateClient(clientName);
+        httpClient.Should().NotBeNull();
+
+        serviceProvider.GetService<IHttpClientWithCache>().Should().NotBeNull().And.BeOfType<HttpClientWithCache>();
+        serviceProvider.GetService<IMemoryCache>().Should().NotBeNull();
+        serviceProvider.GetService<ISimpleCacheKeyGenerator>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddHttpClientWithCache_MultipleCalls_DoesNotThrow()
+    {
+        // Arrange
+        const string clientName = "CachedClient";
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHttpClient();
+        services.AddSingleton<IHttpResponseHandler, DefaultHttpResponseHandler>();
+
+        // Act & Assert
+        Func<IServiceCollection> act = () => services
+            .AddHttpClientWithCache(clientName)
+            .AddHttpClientWithCache(clientName);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void AddResilientHttpClientWithCache_MultipleCalls_DoesNotThrow()
+    {
+        // Arrange
+        const string clientName = "ResilientClient";
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IHttpResponseHandler, DefaultHttpResponseHandler>();
+
+        // Act & Assert
+        Func<IServiceCollection> act = () => services
+            .AddResilientHttpClientWithCache(clientName)
+            .AddResilientHttpClientWithCache(clientName);
+
+        act.Should().NotThrow();
+    }
+}


### PR DESCRIPTION
## Description
This pull request addresses the issue where the `HttpClientWithCache` instance could not be directly resolved as its concrete type through dependency injection (DI). The changes modify the `HttpClientWithCacheExtensions` class to support configuration via `Action<HttpCacheOptions>` instead of directly passing `HttpCacheOptions`, leveraging `IOptionsSnapshot<HttpCacheOptions>` for named client configuration retrieval. A new private factory method, `CreateHttpClientWithCache`, was added to handle the creation of `HttpClientWithCache` instances, utilizing `IOptionsSnapshot` to fetch cache options, ensuring proper DI resolution. New unit tests in `HttpClientWithCacheExtensionsTests` were written to verify the correct registration and configuration of the HTTP client with caching, including named client support and cache options application.

These changes improve the flexibility and usability of the HTTP client with caching by aligning with standard .NET DI practices and ensuring proper configuration scoping.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes
- The XML documentation for the new `CreateHttpClientWithCache` method includes details about parameters and possible exceptions.
- The changes are backward compatible, as the default behavior remains unchanged when no configuration action is provided.
- Related issue: #5 .